### PR TITLE
Adjusting the timing on the overlay animation

### DIFF
--- a/media/js/ColVis.js
+++ b/media/js/ColVis.js
@@ -343,6 +343,11 @@ ColVis.prototype = {
 		{
 			this.s.fnStateChange = oConfig.fnStateChange;
 		}
+		
+		if ( typeof oConfig.iOverlay != 'undefined' )
+		{
+			this.s.iOverlay = oConfig.iOverlay;
+		}
 	},
 	
 	


### PR DESCRIPTION
potatosalad/ColVis@192304ec6b407830d03fd2b986e557bc9b7f835f and potatosalad/ColVis@cb55e0135c8115d80643bee25b10f91fc262bb8a
Adding option 'iOverlay' for adjusting the timing on the overlay animation.

Example:

``` javascript
$(document).ready( function () {
    $('#example').dataTable( {
        "oColVis": {
            "iOverlay": 250
        }
    } );
} );
```
