### PR TITLE
Replacing 'jQuery' variable name with '$' sign

### DIFF
--- a/media/js/ColVis.js
+++ b/media/js/ColVis.js
@@ -837,7 +837,7 @@ ColVis.prototype = {
 			/* In IE6 if you set the checked attribute of a hidden checkbox, then this is not visually
 			 * reflected. As such, we need to do it here, once it is visible. Unbelievable.
 			 */
-			if ( jQuery.browser.msie && jQuery.browser.version == "6.0" )
+			if ( $.browser.msie && $.browser.version == "6.0" )
 			{
 				that._fnDrawCallback();
 			}


### PR DESCRIPTION
Currently in the ColVis plugin, in order to get the browser msie and
version, there were calls to jQuery.browser.msie and
jQuery.browser.version using the jQuery global namespace. While this
might not be an issue while loading the libraries externally, but if
your project has a RequireJS AMD setup then you would led to an error
saying jQuery is not defined. In order to fix this, we could use a $
sign instead of the jQuery namespace to get the browser msie and
version.
