### PR TITLE
Update media/js/ColVis.js

### DIFF
--- a/media/js/ColVis.js
+++ b/media/js/ColVis.js
@@ -450,7 +450,14 @@ ColVis.prototype = {
 		{
 			if ( buttons[i] !== null )
 			{
-				$('input', buttons[i]).prop( 'checked', columns[i].bVisible );
+				if(columns[i].bVisible)
+				{
+					$('input', this.dom.buttons[i]).attr('checked','checked');
+				}
+				else
+				{
+					$('input', this.dom.buttons[i]).removeAttr('checked');
+				}
 			}
 		}
 	},


### PR DESCRIPTION
fixed the bug of the latest commit.
The checked attribute is true when exists (even false), and false when doesn't exist.
