### PR TITLE
Removed dependency to jQuery.browser

### DIFF
--- a/media/js/ColVis.js
+++ b/media/js/ColVis.js
@@ -950,7 +950,8 @@ ColVis.prototype = {
 			/* In IE6 if you set the checked attribute of a hidden checkbox, then this is not visually
 			 * reflected. As such, we need to do it here, once it is visible. Unbelievable.
 			 */
-			if ( $.browser && $.browser.msie && $.browser.version == "6.0" )
+			var asMatches = /(msie) ([\w.]+)/.exec( navigator.userAgent.toLowerCase() ) || []; // detect IE6 the same way jquery.migrate does
+			if ( asMatches[1] === 'msie' && asMatches[2] === '6.0' )
 			{
 				that._fnDrawCallback();
 			}


### PR DESCRIPTION
jQuery removed jQuery.browser in the 2.0 branch. If DataTables.ColVis users want to use jQuery 2.0 they needed jquery.migrate. With this commit the dependency to jQuery.browser is removed so jQuery 2.0 can be used without jquery.migrate.
