### PR TITLE
Fixes server-side loading on column visibility change

### DIFF
--- a/media/js/ColVis.js
+++ b/media/js/ColVis.js
@@ -34,17 +34,17 @@ var ColVis = function( oDTSettings, oInit )
 	{
 		alert( "Warning: ColVis must be initialised with the keyword 'new'" );
 	}
-	
+
 	if ( typeof oInit == 'undefined' )
 	{
 		oInit = {};
 	}
-	
-	
+
+
 	/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 	 * Public class variables
 	 * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-	
+
 	/**
 	 * @namespace Settings object which contains customisable information for ColVis instance
 	 */
@@ -56,7 +56,7 @@ var ColVis = function( oDTSettings, oInit )
 		 *  @default  null
 		 */
 		"dt": null,
-		
+
 		/**
 		 * Customisation object
 		 *  @property oInit
@@ -64,7 +64,7 @@ var ColVis = function( oDTSettings, oInit )
 		 *  @default  passed in
 		 */
 		"oInit": oInit,
-		
+
 		/**
 		 * Callback function to tell the user when the state has changed
 		 *  @property fnStateChange
@@ -72,7 +72,7 @@ var ColVis = function( oDTSettings, oInit )
 		 *  @default  null
 		 */
 		"fnStateChange": null,
-		
+
 		/**
 		 * Mode of activation. Can be 'click' or 'mouseover'
 		 *  @property activate
@@ -80,7 +80,7 @@ var ColVis = function( oDTSettings, oInit )
 		 *  @default  click
 		 */
 		"activate": "click",
-		
+
 		/**
 		 * Position of the collection menu when shown - align "left" or "right"
 		 *  @property sAlign
@@ -88,7 +88,7 @@ var ColVis = function( oDTSettings, oInit )
 		 *  @default  right
 		 */
 		"sAlign": "left",
-		
+
 		/**
 		 * Text used for the button
 		 *  @property buttonText
@@ -96,7 +96,7 @@ var ColVis = function( oDTSettings, oInit )
 		 *  @default  Show / hide columns
 		 */
 		"buttonText": "Show / hide columns",
-		
+
 		/**
 		 * Flag to say if the collection is hidden
 		 *  @property hidden
@@ -104,7 +104,7 @@ var ColVis = function( oDTSettings, oInit )
 		 *  @default  true
 		 */
 		"hidden": true,
-		
+
 		/**
 		 * List of columns (integers) which should be excluded from the list
 		 *  @property aiExclude
@@ -112,7 +112,7 @@ var ColVis = function( oDTSettings, oInit )
 		 *  @default  []
 		 */
 		"aiExclude": [],
-		
+
 		/**
 		 * Group buttons
 		 *  @property aoGroups
@@ -120,7 +120,7 @@ var ColVis = function( oDTSettings, oInit )
 		 *  @default  []
 		 */
 		"aoGroups": [],
-		
+
 		/**
 		 * Store the original viisbility settings so they could be restored
 		 *  @property abOriginal
@@ -128,7 +128,7 @@ var ColVis = function( oDTSettings, oInit )
 		 *  @default  []
 		 */
 		"abOriginal": [],
-		
+
 		/**
 		 * Show Show-All button
 		 *  @property bShowAll
@@ -136,7 +136,7 @@ var ColVis = function( oDTSettings, oInit )
 		 *  @default  []
 		 */
 		"bShowAll": false,
-		
+
 		/**
 		 * Show All button text
 		 *  @property sShowAll
@@ -144,7 +144,7 @@ var ColVis = function( oDTSettings, oInit )
 		 *  @default  Restore original
 		 */
 		"sShowAll": "Show All",
-		
+
 		/**
 		 * Show restore button
 		 *  @property bRestore
@@ -152,7 +152,7 @@ var ColVis = function( oDTSettings, oInit )
 		 *  @default  []
 		 */
 		"bRestore": false,
-		
+
 		/**
 		 * Restore button text
 		 *  @property sRestore
@@ -160,7 +160,7 @@ var ColVis = function( oDTSettings, oInit )
 		 *  @default  Restore original
 		 */
 		"sRestore": "Restore original",
-		
+
 		/**
 		 * Overlay animation duration in mS
 		 *  @property iOverlayFade
@@ -168,7 +168,7 @@ var ColVis = function( oDTSettings, oInit )
 		 *  @default  500
 		 */
 		"iOverlayFade": 500,
-		
+
 		/**
 		 * Label callback for column names. Takes three parameters: 1. the column index, 2. the column
 		 * title detected by DataTables and 3. the TH node for the column
@@ -177,7 +177,7 @@ var ColVis = function( oDTSettings, oInit )
 		 *  @default  null
 		 */
 		"fnLabel": null,
-		
+
 		/**
 		 * Indicate if ColVis should automatically calculate the size of buttons or not. The default
 		 * is for it to do so. Set to "css" to disable the automatic sizing
@@ -186,7 +186,7 @@ var ColVis = function( oDTSettings, oInit )
 		 *  @default  auto
 		 */
 		"sSize": "auto",
-		
+
 		/**
 		 * Indicate if the column list should be positioned by Javascript, visually below the button
 		 * or allow CSS to do the positioning
@@ -196,8 +196,8 @@ var ColVis = function( oDTSettings, oInit )
 		 */
 		"bCssPosition": false
 	};
-	
-	
+
+
 	/**
 	 * @namespace Common and useful DOM elements for the class instance
 	 */
@@ -209,7 +209,7 @@ var ColVis = function( oDTSettings, oInit )
 		 *  @default  null
 		 */
 		"wrapper": null,
-		
+
 		/**
 		 * Activation button
 		 *  @property button
@@ -217,7 +217,7 @@ var ColVis = function( oDTSettings, oInit )
 		 *  @default  null
 		 */
 		"button": null,
-		
+
 		/**
 		 * Collection list node
 		 *  @property collection
@@ -225,7 +225,7 @@ var ColVis = function( oDTSettings, oInit )
 		 *  @default  null
 		 */
 		"collection": null,
-		
+
 		/**
 		 * Background node used for shading the display and event capturing
 		 *  @property background
@@ -233,7 +233,7 @@ var ColVis = function( oDTSettings, oInit )
 		 *  @default  null
 		 */
 		"background": null,
-		
+
 		/**
 		 * Element to position over the activation button to catch mouse events when using mouseover
 		 *  @property catcher
@@ -241,7 +241,7 @@ var ColVis = function( oDTSettings, oInit )
 		 *  @default  null
 		 */
 		"catcher": null,
-		
+
 		/**
 		 * List of button elements
 		 *  @property buttons
@@ -249,7 +249,7 @@ var ColVis = function( oDTSettings, oInit )
 		 *  @default  []
 		 */
 		"buttons": [],
-		
+
 		/**
 		 * List of group button elements
 		 *  @property groupButtons
@@ -266,10 +266,10 @@ var ColVis = function( oDTSettings, oInit )
 		 */
 		"restore": null
 	};
-	
+
 	/* Store global reference */
 	ColVis.aInstances.push( this );
-	
+
 	/* Constructor logic */
 	this.s.dt = oDTSettings;
 	this._fnConstruct();
@@ -282,7 +282,7 @@ ColVis.prototype = {
 	/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 	 * Public methods
 	 * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-	
+
 	/**
 	 * Rebuild the list of buttons for this instance (i.e. if there is a column header update)
 	 *  @method  fnRebuild
@@ -299,26 +299,26 @@ ColVis.prototype = {
 			}
 		}
 		this.dom.buttons.splice( 0, this.dom.buttons.length );
-		
+
 		if ( this.dom.restore )
 		{
 			this.dom.restore.parentNode( this.dom.restore );
 		}
-		
+
 		/* Re-add them (this is not the optimal way of doing this, it is fast and effective) */
 		this._fnAddGroups();
 		this._fnAddButtons();
-		
+
 		/* Update the checkboxes */
 		this._fnDrawCallback();
 	},
-	
-	
-	
+
+
+
 	/* * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * *
 	 * Private methods (they are of course public in JS, but recommended as private)
 	 * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * * */
-	
+
 	/**
 	 * Constructor logic
 	 *  @method  _fnConstruct
@@ -328,29 +328,29 @@ ColVis.prototype = {
 	"_fnConstruct": function ()
 	{
 		this._fnApplyCustomisation();
-		
+
 		var that = this;
 		var i, iLen;
 		this.dom.wrapper = document.createElement('div');
 		this.dom.wrapper.className = "ColVis TableTools";
-		
+
 		this.dom.button = this._fnDomBaseButton( this.s.buttonText );
 		this.dom.button.className += " ColVis_MasterButton";
 		this.dom.wrapper.appendChild( this.dom.button );
-		
+
 		this.dom.catcher = this._fnDomCatcher();
 		this.dom.collection = this._fnDomCollection();
 		this.dom.background = this._fnDomBackground();
-		
+
 		this._fnAddGroups();
 		this._fnAddButtons();
-		
+
 		/* Store the original visbility information */
 		for ( i=0, iLen=this.s.dt.aoColumns.length ; i<iLen ; i++ )
 		{
 			this.s.abOriginal.push( this.s.dt.aoColumns[i].bVisible );
 		}
-		
+
 		/* Update on each draw */
 		this.s.dt.aoDrawCallback.push( {
 			"fn": function () {
@@ -369,12 +369,12 @@ ColVis.prototype = {
 
 			var mStore = that.s.abOriginal.splice( oReorder.iFrom, 1 )[0];
 			that.s.abOriginal.splice( oReorder.iTo, 0, mStore );
-			
+
 			that.fnRebuild();
 		} );
 	},
-	
-	
+
+
 	/**
 	 * Apply any customisation to the settings from the DataTables initialisation
 	 *  @method  _fnApplyCustomisation
@@ -384,62 +384,62 @@ ColVis.prototype = {
 	"_fnApplyCustomisation": function ()
 	{
 		var oConfig = this.s.oInit;
-		
+
 		if ( typeof oConfig.activate != 'undefined' )
 		{
 			this.s.activate = oConfig.activate;
 		}
-		
+
 		if ( typeof oConfig.buttonText != 'undefined' )
 		{
 			this.s.buttonText = oConfig.buttonText;
 		}
-		
+
 		if ( typeof oConfig.aiExclude != 'undefined' )
 		{
 			this.s.aiExclude = oConfig.aiExclude;
 		}
-		
+
 		if ( typeof oConfig.bRestore != 'undefined' )
 		{
 			this.s.bRestore = oConfig.bRestore;
 		}
-		
+
 		if ( typeof oConfig.sRestore != 'undefined' )
 		{
 			this.s.sRestore = oConfig.sRestore;
 		}
-		
+
 		if ( typeof oConfig.bShowAll != 'undefined' )
 		{
 			this.s.bShowAll = oConfig.bShowAll;
 		}
-		
+
 		if ( typeof oConfig.sShowAll != 'undefined' )
 		{
 			this.s.sShowAll = oConfig.sShowAll;
 		}
-		
+
 		if ( typeof oConfig.sAlign != 'undefined' )
 		{
 			this.s.sAlign = oConfig.sAlign;
 		}
-		
+
 		if ( typeof oConfig.fnStateChange != 'undefined' )
 		{
 			this.s.fnStateChange = oConfig.fnStateChange;
 		}
-		
+
 		if ( typeof oConfig.iOverlayFade != 'undefined' )
 		{
 			this.s.iOverlayFade = oConfig.iOverlayFade;
 		}
-		
+
 		if ( typeof oConfig.fnLabel != 'undefined' )
 		{
 			this.s.fnLabel = oConfig.fnLabel;
 		}
-		
+
 		if ( typeof oConfig.sSize != 'undefined' )
 		{
 			this.s.sSize = oConfig.sSize;
@@ -455,8 +455,8 @@ ColVis.prototype = {
 			this.s.aoGroups = oConfig.aoGroups;
 		}
 	},
-	
-	
+
+
 	/**
 	 * On each table draw, check the visibility checkboxes as needed. This allows any process to
 	 * update the table's column visibility and ColVis will still be accurate.
@@ -469,7 +469,7 @@ ColVis.prototype = {
 		var columns = this.s.dt.aoColumns;
 		var buttons = this.dom.buttons;
 		var groups = this.s.aoGroups;
-		
+
 		for ( var i=0, iLen=columns.length ; i<iLen ; i++ )
 		{
 			if ( buttons[i] !== null )
@@ -533,8 +533,8 @@ ColVis.prototype = {
 			}
 		}
 	},
-	
-	
+
+
 	/**
 	 * Loop through the columns in the table and as a new button for each one.
 	 *  @method  _fnAddButtons
@@ -546,7 +546,7 @@ ColVis.prototype = {
 		var
 			nButton,
 			sExclude = ","+this.s.aiExclude.join(',')+",";
-		
+
 		if ( $.inArray( 'all', this.s.aiExclude ) === -1 ) {
 			for ( var i=0, iLen=this.s.dt.aoColumns.length ; i<iLen ; i++ )
 			{
@@ -562,7 +562,7 @@ ColVis.prototype = {
 				}
 			}
 		}
-		
+
 		if ( this.s.bRestore )
 		{
 			nButton = this._fnDomRestoreButton();
@@ -570,7 +570,7 @@ ColVis.prototype = {
 			this.dom.buttons.push( nButton );
 			this.dom.collection.appendChild( nButton );
 		}
-		
+
 		if ( this.s.bShowAll )
 		{
 			nButton = this._fnDomShowAllButton();
@@ -579,8 +579,8 @@ ColVis.prototype = {
 			this.dom.collection.appendChild( nButton );
 		}
 	},
-	
-	
+
+
 	/**
 	 * Create a button which allows a "restore" action
 	 *  @method  _fnDomRestoreButton
@@ -593,12 +593,12 @@ ColVis.prototype = {
 			that = this,
 			nButton = document.createElement('button'),
 			nSpan = document.createElement('span');
-		
+
 		nButton.className = !this.s.dt.bJUI ? "ColVis_Button TableTools_Button" :
 			"ColVis_Button TableTools_Button ui-button ui-state-default";
 		nButton.appendChild( nSpan );
 		$(nSpan).html( '<span class="ColVis_title">'+this.s.sRestore+'</span>' );
-		
+
 		$(nButton).click( function (e) {
 			for ( var i=0, iLen=that.s.abOriginal.length ; i<iLen ; i++ )
 			{
@@ -608,11 +608,11 @@ ColVis.prototype = {
 			that.s.dt.oInstance.fnAdjustColumnSizing( false );
 			that.s.dt.oInstance.fnDraw( false );
 		} );
-		
+
 		return nButton;
 	},
-	
-	
+
+
 	/**
 	 * Create a button which allows a "show all" action
 	 *  @method  _fnDomShowAllButton
@@ -625,12 +625,12 @@ ColVis.prototype = {
 			that = this,
 			nButton = document.createElement('button'),
 			nSpan = document.createElement('span');
-		
+
 		nButton.className = !this.s.dt.bJUI ? "ColVis_Button TableTools_Button" :
 			"ColVis_Button TableTools_Button ui-button ui-state-default";
 		nButton.appendChild( nSpan );
 		$(nSpan).html( '<span class="ColVis_title">'+this.s.sShowAll+'</span>' );
-		
+
 		$(nButton).click( function (e) {
 			for ( var i=0, iLen=that.s.abOriginal.length ; i<iLen ; i++ )
 			{
@@ -643,11 +643,11 @@ ColVis.prototype = {
 			that.s.dt.oInstance.fnAdjustColumnSizing( false );
 			that.s.dt.oInstance.fnDraw( false );
 		} );
-		
+
 		return nButton;
 	},
-	
-	
+
+
 	/**
 	 * Create the DOM for a show / hide group button
 	 *  @method  _fnDomGroupButton
@@ -705,7 +705,7 @@ ColVis.prototype = {
 			nButton = document.createElement('button'),
 			nSpan = document.createElement('span'),
 			dt = this.s.dt;
-		
+
 		nButton.className = !dt.bJUI ? "ColVis_Button TableTools_Button" :
 			"ColVis_Button TableTools_Button ui-button ui-state-default";
 		nButton.appendChild( nSpan );
@@ -713,14 +713,14 @@ ColVis.prototype = {
 		$(nSpan).html(
 			'<span class="ColVis_radio"><input type="checkbox" checked=""/></span>'+
 			'<span class="ColVis_title">'+sTitle+'</span>' );
-		
+
 		$(nButton).click( function (e) {
 			var showHide = !$('input', this).is(":checked");
 			if ( e.target.nodeName.toLowerCase() == "input" )
 			{
 				showHide = $('input', this).is(":checked");
 			}
-			
+
 			/* Need to consider the case where the initialiser created more than one table - change the
 			 * API index that DataTables is using
 			 */
@@ -728,11 +728,14 @@ ColVis.prototype = {
 			$.fn.dataTableExt.iApiIndex = that._fnDataTablesApiIndex.call(that);
 
 			// Optimisation for server-side processing when scrolling - don't do a full redraw
-			if ( dt.oFeatures.bServerSide && (dt.oScroll.sX !== "" || dt.oScroll.sY !== "" ) )
+			if ( dt.oFeatures.bServerSide )
 			{
 				that.s.dt.oInstance.fnSetColumnVis( i, showHide, false );
 				that.s.dt.oInstance.fnAdjustColumnSizing( false );
-				that.s.dt.oInstance.oApi._fnScrollDraw( that.s.dt );
+				if (dt.oScroll.sX !== "" || dt.oScroll.sY !== "" )
+				{
+					that.s.dt.oInstance.oApi._fnScrollDraw( that.s.dt );
+				}
 				that._fnDrawCallback();
 			}
 			else
@@ -741,17 +744,17 @@ ColVis.prototype = {
 			}
 
 			$.fn.dataTableExt.iApiIndex = oldIndex; /* Restore */
-			
+
 			if ( that.s.fnStateChange !== null )
 			{
 				that.s.fnStateChange.call( that, i, showHide );
 			}
 		} );
-		
+
 		return nButton;
 	},
-	
-	
+
+
 	/**
 	 * Get the position in the DataTables instance array of the table for this instance of ColVis
 	 *  @method  _fnDataTablesApiIndex
@@ -769,8 +772,8 @@ ColVis.prototype = {
 		}
 		return 0;
 	},
-	
-	
+
+
 	/**
 	 * Create the DOM needed for the button and apply some base properties. All buttons start here
 	 *  @method  _fnDomBaseButton
@@ -785,21 +788,21 @@ ColVis.prototype = {
 			nButton = document.createElement('button'),
 			nSpan = document.createElement('span'),
 			sEvent = this.s.activate=="mouseover" ? "mouseover" : "click";
-		
+
 		nButton.className = !this.s.dt.bJUI ? "ColVis_Button TableTools_Button" :
 			"ColVis_Button TableTools_Button ui-button ui-state-default";
 		nButton.appendChild( nSpan );
 		nSpan.innerHTML = text;
-		
+
 		$(nButton).bind( sEvent, function (e) {
 			that._fnCollectionShow();
 			e.preventDefault();
 		} );
-		
+
 		return nButton;
 	},
-	
-	
+
+
 	/**
 	 * Create the element used to contain list the columns (it is shown and hidden as needed)
 	 *  @method  _fnDomCollection
@@ -813,17 +816,17 @@ ColVis.prototype = {
 		nHidden.style.display = "none";
 		nHidden.className = !this.s.dt.bJUI ? "ColVis_collection TableTools_collection" :
 			"ColVis_collection TableTools_collection ui-buttonset ui-buttonset-multi";
-		
+
 		if ( !this.s.bCssPosition )
 		{
 			nHidden.style.position = "absolute";
 		}
 		$(nHidden).css('opacity', 0);
-		
+
 		return nHidden;
 	},
-	
-	
+
+
 	/**
 	 * An element to be placed on top of the activate button to catch events
 	 *  @method  _fnDomCatcher
@@ -836,15 +839,15 @@ ColVis.prototype = {
 			that = this,
 			nCatcher = document.createElement('div');
 		nCatcher.className = "ColVis_catcher TableTools_catcher";
-		
+
 		$(nCatcher).click( function () {
 			that._fnCollectionHide.call( that, null, null );
 		} );
-		
+
 		return nCatcher;
 	},
-	
-	
+
+
 	/**
 	 * Create the element used to shade the background, and capture hide events (it is shown and
 	 * hidden as needed)
@@ -855,14 +858,14 @@ ColVis.prototype = {
 	"_fnDomBackground": function ()
 	{
 		var that = this;
-		
+
 		var background = $('<div></div>')
 			.addClass( 'ColVis_collectionBackground TableTools_collectionBackground' )
 			.css( 'opacity', 0 )
 			.click( function () {
 				that._fnCollectionHide.call( that, null, null );
 			} );
-		
+
 		/* When considering a mouse over action for the activation, we also consider a mouse out
 		 * which is the same as a mouse over the background - without all the messing around of
 		 * bubbling events. Use the catcher element to avoid messing around with bubbling
@@ -874,11 +877,11 @@ ColVis.prototype = {
 				that._fnCollectionHide.call( that, null, null );
 			} );
 		}
-		
+
 		return background[0];
 	},
-	
-	
+
+
 	/**
 	 * Show the show / hide list and the background
 	 *  @method  _fnCollectionShow
@@ -893,31 +896,31 @@ ColVis.prototype = {
 		var nBackground = this.dom.background;
 		var iDivX = parseInt(oPos.left, 10);
 		var iDivY = parseInt(oPos.top + $(this.dom.button).outerHeight(), 10);
-		
+
 		if ( !this.s.bCssPosition )
 		{
 			nHidden.style.top = iDivY+"px";
 			nHidden.style.left = iDivX+"px";
 		}
-		
+
 		$(nHidden).css( {
 			'display': 'block',
 			'opacity': 0
 		} );
-		
+
 		nBackground.style.bottom ='0px';
 		nBackground.style.right = '0px';
-		
+
 		var oStyle = this.dom.catcher.style;
 		oStyle.height = $(this.dom.button).outerHeight()+"px";
 		oStyle.width = $(this.dom.button).outerWidth()+"px";
 		oStyle.top = oPos.top+"px";
 		oStyle.left = iDivX+"px";
-		
+
 		document.body.appendChild( nBackground );
 		document.body.appendChild( nHidden );
 		document.body.appendChild( this.dom.catcher );
-		
+
 		/* Resize the buttons */
 		if ( this.s.sSize == "auto" )
 		{
@@ -941,7 +944,7 @@ ColVis.prototype = {
 			}
 			this.dom.collection.style.width = iMax+"px";
 		}
-		
+
 		/* This results in a very small delay for the end user but it allows the animation to be
 		 * much smoother. If you don't want the animation, then the setTimeout can be removed
 		 */
@@ -955,7 +958,7 @@ ColVis.prototype = {
 				that._fnDrawCallback();
 			}
 		});
-		
+
 		/* Visual corrections to try and keep the collection visible */
 		if ( !this.s.bCssPosition )
 		{
@@ -968,17 +971,17 @@ ColVis.prototype = {
 			var iDivWidth = $(nHidden).outerWidth();
 			var iDivHeight = $(nHidden).outerHeight();
 			var iDocWidth = $(document).width();
-			
+
 			if ( iLeft + iDivWidth > iDocWidth )
 			{
 				nHidden.style.left = (iDocWidth-iDivWidth)+"px";
 			}
 		}
-		
+
 		this.s.hidden = false;
 	},
-	
-	
+
+
 	/**
 	 * Hide the show / hide list and the background
 	 *  @method  _fnCollectionHide
@@ -988,23 +991,23 @@ ColVis.prototype = {
 	"_fnCollectionHide": function (  )
 	{
 		var that = this;
-		
+
 		if ( !this.s.hidden && this.dom.collection !== null )
 		{
 			this.s.hidden = true;
-			
+
 			$(this.dom.collection).animate({"opacity": 0}, that.s.iOverlayFade, function (e) {
 				this.style.display = "none";
 			} );
-			
+
 			$(this.dom.background).animate({"opacity": 0}, that.s.iOverlayFade, function (e) {
 				document.body.removeChild( that.dom.background );
 				document.body.removeChild( that.dom.catcher );
 			} );
 		}
 	},
-	
-	
+
+
 	/**
 	 * Alter the colspan on any fnOpen rows
 	 */
@@ -1012,7 +1015,7 @@ ColVis.prototype = {
 	{
 		var aoOpen = this.s.dt.aoOpenRows;
 		var iVisible = this.s.dt.oApi._fnVisbleColumns( this.s.dt );
-		
+
 		for ( var i=0, iLen=aoOpen.length ; i<iLen ; i++ ) {
 			aoOpen[i].nTr.getElementsByTagName('td')[0].colSpan = iVisible;
 		}
@@ -1041,7 +1044,7 @@ ColVis.fnRebuild = function ( oTable )
 	{
 		nTable = oTable.fnSettings().nTable;
 	}
-	
+
 	for ( var i=0, iLen=ColVis.aInstances.length ; i<iLen ; i++ )
 	{
 		if ( typeof oTable == 'undefined' || nTable == ColVis.aInstances[i].s.dt.nTable )


### PR DESCRIPTION
When showing or hiding a column toggle a server side refresh.

Based on the messages posted in [this forum thread](http://datatables.net/forums/discussion/12632/colvis-prevent-refresh-on-serverside-table-unles-re-sorted-or-page-changed/p1) I was able to identify the underlying problem to prevent server-side refresh.

The initial comment of allan "paved" the way to make this correction.
