### PR TITLE
Fixed multiple calls to 'fnStateChange'

### DIFF
--- a/js/dataTables.colVis.js
+++ b/js/dataTables.colVis.js
@@ -627,7 +627,7 @@ ColVis.prototype = {
 
 				$.fn.dataTableExt.iApiIndex = oldIndex; /* Restore */
 
-				if ( that.s.fnStateChange !== null )
+				if ( e.target.nodeName.toLowerCase() === 'input' && that.s.fnStateChange !== null )
 				{
 					that.s.fnStateChange.call( that, i, showHide );
 				}


### PR DESCRIPTION
The 'fnStateChange' was called twice when clicking on the column title.

Regards,
Giacomo
