### PR TITLE
Fix fnDOMColumnButton's click event handler

### DIFF
--- a/js/dataTables.colVis.js
+++ b/js/dataTables.colVis.js
@@ -610,7 +610,10 @@ ColVis.prototype = {
 				var showHide = !$('input', this).is(":checked");
 				if (  e.target.nodeName.toLowerCase() !== "li" )
 				{
-					showHide = ! showHide;
+					if ( e.target.nodeName.toLowerCase() == "input" || that.s.fnStateChange === null )
+					{
+						showHide = ! showHide;
+					}
 				}
 
 				/* Need to consider the case where the initialiser created more than one table - change the
@@ -637,8 +640,12 @@ ColVis.prototype = {
 
 				$.fn.dataTableExt.iApiIndex = oldIndex; /* Restore */
 
-				if ( e.target.nodeName.toLowerCase() === 'input' && that.s.fnStateChange !== null )
+				if ( that.s.fnStateChange !== null )
 				{
+					if ( e.target.nodeName.toLowerCase() == "span" )
+					{
+						e.preventDefault();
+					}
 					that.s.fnStateChange.call( that, i, showHide );
 				}
 			} )[0];


### PR DESCRIPTION
Addresses #32.

What I suppose was happening was the span triggered a click event on its sibling input by default. So this PR prevents the span's (and only the span's) default action.

Also if the span is clicked and fnStateChange is not null, then don't negate `showHide` in the [if block][1].

  [1]: https://github.com/DataTables/ColVis/pull/35/files#diff-ba919773df06fa2df6072b3b2aa6b0e0L611